### PR TITLE
fix: Limit pfps to owners and admins

### DIFF
--- a/dex-demo/client/src/components/ViewAssetPfp.tsx
+++ b/dex-demo/client/src/components/ViewAssetPfp.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../contexts/AuthContext.js";
 import { useApi } from "../contexts/ApiContext.js";
 import { Button } from "@mui/material";
 
-function ViewAssetPfp({ asset, onSave }: { asset: any, onSave: () => void }) {
+function ViewAssetPfp({ asset, isAssetOwner, isCollectionOwner, onSave }: { asset: any, isAssetOwner: boolean, isCollectionOwner: boolean, onSave: () => void }) {
     const { did } = useParams();
     const auth = useAuth();
     const api = useApi();
@@ -63,18 +63,26 @@ function ViewAssetPfp({ asset, onSave }: { asset: any, onSave: () => void }) {
                     borderRadius: '50%',
                 }}
             />
-            <Button variant="contained" color="primary" onClick={setProfilePic}>
-                Set Profile Pic
-            </Button>
-            <Button variant="contained" color="primary" onClick={setCollectionThumbnail}>
-                Set Collection Thumbnail
-            </Button>
-            <Button variant="contained" color="primary" onClick={setDefaultPfp}>
-                Set Default Pfp
-            </Button>
-            <Button variant="contained" color="primary" onClick={setDefaultThumbnail}>
-                Set Default Thumbnail
-            </Button>
+            {isAssetOwner &&
+                <Button variant="contained" color="primary" onClick={setProfilePic}>
+                    Set Profile Pic
+                </Button>
+            }
+            {isCollectionOwner &&
+                <Button variant="contained" color="primary" onClick={setCollectionThumbnail}>
+                    Set Collection Thumbnail
+                </Button>
+            }
+            {auth.isAdmin &&
+                <>
+                    <Button variant="contained" color="primary" onClick={setDefaultPfp}>
+                        Set Default Pfp
+                    </Button>
+                    <Button variant="contained" color="primary" onClick={setDefaultThumbnail}>
+                        Set Default Thumbnail
+                    </Button>
+                </>
+            }
         </div>
     );
 }


### PR DESCRIPTION
This PR restricts profile picture (PFP) functionality to asset owners, collection owners, and admins. Previously, the PFP tab was accessible to all authenticated users.

Key Changes:

-    Added ownership checks to determine who can view and use PFP functionality
-    Updated PFP button visibility to respect ownership permissions
-    Modified owner calculation to prioritize token owner over matrix owner
